### PR TITLE
Remove all option from the setupwizard

### DIFF
--- a/setup-wizard.yml
+++ b/setup-wizard.yml
@@ -11,7 +11,6 @@ fields:
       You can change this parameter in the future
     enum:
       - prysm
-      - all
       - teku
       - lighthouse
       - nimbus


### PR DESCRIPTION
For security reasons, remove the **all** option from the setup-wizard. This option is still allowed in the `entrypoint` but will have to be set up through the custom editor