### PR TITLE
Update lodestar api token

### DIFF
--- a/web3signer/security/lodestar/api-token.txt
+++ b/web3signer/security/lodestar/api-token.txt
@@ -1,1 +1,1 @@
-Authorization: bearer api-token-0x7fd16fff6453982a5d8bf14617e7823b68cd18ade59985befe64e0a659300e7d
+api-token-0x7fd16fff6453982a5d8bf14617e7823b68cd18ade59985befe64e0a659300e7d


### PR DESCRIPTION
Lodestar api token format was incorrect and was fixed in this PR https://github.com/dappnode/DAppNodePackage-Lodestar-Prater/pull/25 on the Lodestar package. Need to align the values else authentication would fail.