### PR TITLE
Increase idle timeout

### DIFF
--- a/web3signer/entrypoint.sh
+++ b/web3signer/entrypoint.sh
@@ -66,7 +66,7 @@ exec /opt/web3signer/bin/web3signer \
   --metrics-host 0.0.0.0 \
   --metrics-port 9091 \
   --metrics-host-allowlist="*" \
-  --idle-connection-timeout-seconds=90 \
+  --idle-connection-timeout-seconds=900 \
   eth2 \
   --network=prater \
   --slashing-protection-db-url=jdbc:postgresql://postgres.web3signer-prater.dappnode:5432/web3signer \


### PR DESCRIPTION
Increase idle timeout to allow importing many keystores in a single import.

1 Keystore import takes 0.6 secs aprox