### PR TITLE
Fixing database backup

### DIFF
--- a/dappnode_package.json
+++ b/dappnode_package.json
@@ -53,7 +53,7 @@
     },
     {
       "name": "brain-db",
-      "path": "/app/brain-db.json",
+      "path": "/app/data/brain-db.json",
       "service": "brain"
     }
   ]


### PR DESCRIPTION
I fixed the path for the brain-db.json file because it wasn't being downloaded in the backup.