### PR TITLE
Remove brain webpack

### DIFF
--- a/brain/Dockerfile
+++ b/brain/Dockerfile
@@ -1,2 +1,2 @@
-FROM ghcr.io/dappnode/staking-brain-webpack:0.1.7
+FROM ghcr.io/dappnode/staking-brain:0.1.7
 ENV NETWORK=prater


### PR DESCRIPTION
Webpack in brain is causing `ethers` library to fail in the web3signer package. It is used to retrieve fee recipient for keystores registered in stakehouse protocol:

```
Error: could not detect network (event="noNetwork", code=NETWORK_ERROR, version=providers/5.7.2)
    at Logger.makeError (file:///app/index.js:2888:23)
    at Logger.throwError (file:///app/index.js:2897:20)
    at JsonRpcProvider.<anonymous> (file:///app/index.js:6411:27)
    at Generator.throw (<anonymous>)
    at rejected (file:///app/index.js:5975:65) {
  reason: 'could not detect network',
  code: 'NETWORK_ERROR',
  event: 'noNetwork'
}```

Removing webpack fixes the issue