### PR TITLE
Bump brain to 0.1.8

### DIFF
--- a/brain/Dockerfile
+++ b/brain/Dockerfile
@@ -1,2 +1,2 @@
-FROM ghcr.io/dappnode/staking-brain:0.1.7
+FROM ghcr.io/dappnode/staking-brain:0.1.8
 ENV NETWORK=prater


### PR DESCRIPTION
Staking Brain updated to version 0.1.8, which fixes issue with exit message not being properly posted