### PR TITLE
Remove depends_on healthy

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -4,9 +4,6 @@ services:
     image: "brain.web3signer-prater.dnp.dappnode.eth:0.1.13"
     build:
       context: brain
-    depends_on:
-      web3signer:
-        condition: service_healthy
     environment:
       - LOG_LEVEL=debug
     restart: unless-stopped


### PR DESCRIPTION
This dependency is causing some trouble when web3signer is not properly installed, as the signer service becomes unhealthy and the dappmanager is not able to run a rollback