### PR TITLE
Make JAVA OPTs user configurable in the advanced config editor

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -29,6 +29,7 @@ services:
       args:
         UPSTREAM_VERSION: 23.11.0
     environment:
+      JAVA_OPTS: "-Xmx4g -Xms128m"
       EXTRA_OPTS: ""
     volumes:
       - "web3signer_data:/data"

--- a/web3signer/Dockerfile
+++ b/web3signer/Dockerfile
@@ -12,6 +12,5 @@ COPY /security /security
 COPY entrypoint.sh /usr/bin/entrypoint.sh
 
 #USER web3signer
-ENV JAVA_OPTS="-Xmx4g -Xms128m"
 EXPOSE 9000
 ENTRYPOINT /bin/bash /usr/bin/entrypoint.sh


### PR DESCRIPTION
Same logic as https://github.com/dappnode/DAppNodePackage-web3signer-gnosis/pull/76
but does not change the defaults, just moves them from hardcoded in the dockerfile to being configurable in the compose file.