### PR TITLE
Allow editing worker pool size

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -31,7 +31,7 @@ services:
     environment:
       JAVA_OPTS: "-Xmx6g"
       EXTRA_OPTS: ""
-      WEB3SIGNER_VERTX_WORKER_POOL_SIZE: "40"
+      WEB3SIGNER_VERTX_WORKER_POOL_SIZE: "20"
     volumes:
       - "web3signer_data:/data"
     restart: unless-stopped

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -31,6 +31,7 @@ services:
     environment:
       JAVA_OPTS: "-Xmx6g"
       EXTRA_OPTS: ""
+      WEB3SIGNER_VERTX_WORKER_POOL_SIZE: "40"
     volumes:
       - "web3signer_data:/data"
     restart: unless-stopped


### PR DESCRIPTION
Allow the user to edit `vertx-worker-pool-size` to handle CPU/memory consumption, together with `JAVA_OPTS`