### PR TITLE
Bump brain 0.1.16

### DIFF
--- a/brain/Dockerfile
+++ b/brain/Dockerfile
@@ -1,2 +1,2 @@
-FROM ghcr.io/dappnode/staking-brain:0.1.14
+FROM ghcr.io/dappnode/staking-brain:0.1.16
 ENV NETWORK=prater


### PR DESCRIPTION
Bump brain to v0.1.16 (https://github.com/dappnode/StakingBrain/releases/tag/0.1.16)