### PR TITLE
Bump brain 0.1.17

### DIFF
--- a/brain/Dockerfile
+++ b/brain/Dockerfile
@@ -1,2 +1,2 @@
-FROM ghcr.io/dappnode/staking-brain:0.1.16
+FROM ghcr.io/dappnode/staking-brain:0.1.17
 ENV NETWORK=prater


### PR DESCRIPTION
Bump brain to `v0.1.17` to match new auth-token for Prysm validator